### PR TITLE
Rename test case

### DIFF
--- a/frameworks/native/tests/lib.rs
+++ b/frameworks/native/tests/lib.rs
@@ -19,7 +19,7 @@ mod framework_spec {
 	use parenchyma_native::Native;
 
 	#[test]
-	fn it_works() {
+	fn it_can_get_native_device() {
 		let framework = Native::new();
 		assert_eq!(framework.devices().len(), 1);
 	}


### PR DESCRIPTION
It's quite a minor update(or suggestion).
How about rename test case as on commit, because other cases has proper names, related with their test purpose.